### PR TITLE
fix: nothing is ever written to the tmpfs location when  the tmpfs mode is absolute path

### DIFF
--- a/pkg/srpmproc/process.go
+++ b/pkg/srpmproc/process.go
@@ -193,7 +193,7 @@ func NewProcessData(req *ProcessDataRequest) (*data.ProcessData, error) {
 
 	fsCreator := func(branch string) (billy.Filesystem, error) {
 		if req.TmpFsMode != "" {
-			return osfs.New("."), nil
+			return osfs.New(""), nil
 		}
 		return memfs.New(), nil
 	}


### PR DESCRIPTION
After correcting the baseDir argument from "." to "" in newing osfs instance, it works no matter absolute patch or relative path the argument is.

Signed-off-by: jarod.w <wl.jarod@gmail.com>