### PR TITLE
Manual commits fix

### DIFF
--- a/pkg/misc/regex.go
+++ b/pkg/misc/regex.go
@@ -38,8 +38,8 @@ func GetTagImportRegex(pd *data.ProcessData) *regexp.Regexp {
 // if we are ok with importing that reference.  We are looking for the traditional <prefix><version><suffix> pattern, like "c9s", and also the
 // modular "stream-<NAME>-<VERSION>-rhel-<VERSION> branch pattern as well
 func TaglessRefOk(tag string, pd *data.ProcessData) bool {
-	// First case is very easy: if we are "refs/heads/<prefix><version><suffix>" , then this is def. a branch we should import
-	if strings.HasPrefix(tag, fmt.Sprintf("refs/heads/%s%d%s", pd.ImportBranchPrefix, pd.Version, pd.BranchSuffix)) {
+	// First case is very easy: if we are exactly "refs/heads/<prefix><version><suffix>" , then this is def. a branch we should import
+	if tag == fmt.Sprintf("refs/heads/%s%d%s", pd.ImportBranchPrefix, pd.Version, pd.BranchSuffix) {
 		return true
 	}
 


### PR DESCRIPTION
This set of commits alters behavior in a few ways:

- The manual-commits feature now implies tagless mode.  The nvr will be discovered, because it's implied that importing a manual hash means there is no proper import tag present.  This also fixes the manual-commits feature, which hasn't been functioning correctly for a while.

- Fixed a potential issue in the rpmspec command for tagless mode:  stderr output could interfere with the nvr result.  Only stdout is now considered

- Fixed a major issue with tagless mode:  Rename() behavior varies by OS when moving directories.  The target directories are removed first, before the Rename.