### PR TITLE
Force _topdir defines for rpmspec and do not import if clean

### DIFF
--- a/cmd/srpmproc/main.go
+++ b/cmd/srpmproc/main.go
@@ -59,6 +59,7 @@ var (
 	packageRelease       string
 	taglessMode          bool
 	cdn                  string
+	moduleBranchNames    bool
 )
 
 var root = &cobra.Command{
@@ -97,6 +98,7 @@ func mn(_ *cobra.Command, _ []string) {
 		PackageRelease:       packageRelease,
 		TaglessMode:          taglessMode,
 		Cdn:                  cdn,
+		ModuleBranchNames:    moduleBranchNames,
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -148,6 +150,7 @@ func main() {
 	root.Flags().StringVar(&packageRelease, "package-release", "", "Package release to fetch")
 	root.Flags().BoolVar(&taglessMode, "taglessmode", false, "Tagless mode:  If set, pull the latest commit from the branch and determine version numbers from spec file.  This is auto-tried if tags aren't found.")
 	root.Flags().StringVar(&cdn, "cdn", "", "CDN URL shortcuts for well-known distros, auto-assigns --cdn-url.  Valid values:  rocky8, rocky, fedora, centos, centos-stream.  Setting this overrides --cdn-url")
+	root.Flags().BoolVar(&moduleBranchNames, "module-branch-names-only", false, "If enabled, module imports will use the branch name that is being imported, rather than use the commit hash.")
 
 	if err := root.Execute(); err != nil {
 		log.Fatal(err)

--- a/pkg/data/process.go
+++ b/pkg/data/process.go
@@ -60,4 +60,5 @@ type ProcessData struct {
 	PackageRelease       string
 	TaglessMode          bool
 	Cdn                  string
+	ModuleBranchNames    bool
 }

--- a/pkg/srpmproc/patch.go
+++ b/pkg/srpmproc/patch.go
@@ -397,6 +397,12 @@ func patchModuleYaml(pd *data.ProcessData, md *data.ModeData) error {
 			}
 		}
 
+		// If we got this far, we're good. This means the repos, branches, and commits exist.
+		// If this option is on, just use the branch name.
+		if pd.ModuleBranchNames {
+			tipHash = md.PushBranch
+		}
+
 		rpm.Ref = tipHash
 	}
 

--- a/pkg/srpmproc/process.go
+++ b/pkg/srpmproc/process.go
@@ -103,6 +103,8 @@ type ProcessDataRequest struct {
 
 	TaglessMode bool
 	Cdn         string
+
+	ModuleBranchNames bool
 }
 
 type LookasidePath struct {
@@ -335,6 +337,7 @@ func NewProcessData(req *ProcessDataRequest) (*data.ProcessData, error) {
 		PackageRelease:       req.PackageRelease,
 		TaglessMode:          req.TaglessMode,
 		Cdn:                  req.Cdn,
+		ModuleBranchNames:    req.ModuleBranchNames,
 	}, nil
 }
 
@@ -655,6 +658,11 @@ func ProcessRPM(pd *data.ProcessData) (*srpmprocpb.ProcessResponse, error) {
 
 		// show status
 		status, _ := w.Status()
+		if !pd.ModuleMode {
+			if status.IsClean() {
+				return nil, fmt.Errorf("No changes detected. Our downstream is up to date.")
+			}
+		}
 		pd.Log.Printf("successfully processed:\n%s", status)
 
 		statusLines := strings.Split(status.String(), "\n")
@@ -740,7 +748,6 @@ func ProcessRPM(pd *data.ProcessData) (*srpmprocpb.ProcessResponse, error) {
 }
 
 // Process for when we want to import a tagless repo (like from CentOS Stream)
-//
 func processRPMTagless(pd *data.ProcessData) (*srpmprocpb.ProcessResponse, error) {
 	pd.Log.Println("Tagless mode detected, attempting import of latest commit")
 
@@ -993,6 +1000,11 @@ func processRPMTagless(pd *data.ProcessData) (*srpmprocpb.ProcessResponse, error
 		}
 
 		status, err := w.Status()
+		if !pd.ModuleMode {
+			if status.IsClean() {
+				return nil, fmt.Errorf("No changes detected. Our downstream is up to date.")
+			}
+		}
 		pd.Log.Printf("successfully processed:\n%s", status)
 
 		// assign tag for our new remote we're about to push (derived from the SRPM version)
@@ -1208,6 +1220,7 @@ func convertMetaData(pkgName string, localRepo string) bool {
 // Given a local checked out folder and package name, including SPECS/ , SOURCES/ , and .package.metadata, this will:
 //   - create a "dummy" SRPM (using dummy sources files we use to populate tarballs from lookaside)
 //   - extract RPM version info from that SRPM, and return it
+//
 // If we are in tagless mode, we need to get a package version somehow!
 func getVersionFromSpec(localRepo string, majorVersion int) (string, error) {
 	// Make sure we have "rpm" and "rpmbuild" and "cp" available in our PATH.  Otherwise, this won't work:
@@ -1232,6 +1245,7 @@ func getVersionFromSpec(localRepo string, majorVersion int) (string, error) {
 	cmdArgs := []string{
 		"--srpm",
 		fmt.Sprintf(`--define=dist  .el%d`, majorVersion),
+		fmt.Sprintf(`--define=_topdir  %s`, localRepo),
 		"-q",
 		"--queryformat",
 		`%{NAME}|%{VERSION}|%{RELEASE}\n`,


### PR DESCRIPTION
Issue: There are cases where an RPM maintainer has macros or other portions defined in other files and are imported/loaded when rpmbuild -bs or otherwise is called. When running against a spec file that does this, it will fail as it tries to look at `~/rpmbuild/SOURCES` for those files by default.

Setting `_topdir` to the `localRepo` var gets around this issue.

Issue: srpmproc should also not have to import a "clean" repo

Checking IsClean and not importing gets around this and helps keep the commit history clean. This does NOT happen for module imports.

Feature: module-branch-names-only flag added. This makes it so module imports can present a branch name rather than a commit ID. This can make MBS happy and make it simpler to handle MBS builds.