### PR TITLE
Add a flag `--upstream-version` to migrate a package to an other vers…

### DIFF
--- a/cmd/srpmproc/main.go
+++ b/cmd/srpmproc/main.go
@@ -35,6 +35,7 @@ var (
 	sshKeyLocation       string
 	sshUser              string
 	upstreamPrefix       string
+	upstreamVersion      int
 	version              int
 	storageAddr          string
 	gitCommitterName     string
@@ -69,6 +70,7 @@ var root = &cobra.Command{
 func mn(_ *cobra.Command, _ []string) {
 	pd, err := srpmproc.NewProcessData(&srpmproc.ProcessDataRequest{
 		Version:              version,
+		UpstreamVersion:      upstreamVersion,
 		StorageAddr:          storageAddr,
 		Package:              sourceRpm,
 		ModuleMode:           moduleMode,
@@ -120,6 +122,8 @@ func main() {
 	_ = root.MarkFlagRequired("upstream-prefix")
 	root.Flags().IntVar(&version, "version", 0, "Upstream version")
 	_ = root.MarkFlagRequired("version")
+	root.Flags().IntVar(&upstreamVersion, "upstream-version", 0, "Upstream version")
+
 	root.Flags().StringVar(&storageAddr, "storage-addr", "", "Bucket to use as blob storage")
 	_ = root.MarkFlagRequired("storage-addr")
 

--- a/pkg/data/process.go
+++ b/pkg/data/process.go
@@ -34,6 +34,7 @@ type ProcessData struct {
 	RpmLocation          string
 	UpstreamPrefix       string
 	Version              int
+	UpstreamVersion      int
 	GitCommitterName     string
 	GitCommitterEmail    string
 	Mode                 int

--- a/pkg/srpmproc/process.go
+++ b/pkg/srpmproc/process.go
@@ -69,6 +69,7 @@ const (
 type ProcessDataRequest struct {
 	// Required
 	Version     int
+	UpstreamVersion     int
 	StorageAddr string
 	Package     string
 
@@ -170,6 +171,9 @@ func NewProcessData(req *ProcessDataRequest) (*data.ProcessData, error) {
 	logger := log.New(writer, "", log.LstdFlags)
 
 	// Set defaults
+	if req.UpstreamVersion == 0 {
+		req.UpstreamVersion = req.Version
+	}
 	if req.ModulePrefix == "" {
 		req.ModulePrefix = ModulePrefixCentOS
 	}
@@ -311,6 +315,7 @@ func NewProcessData(req *ProcessDataRequest) (*data.ProcessData, error) {
 		RpmLocation:          sourceRpmLocation,
 		UpstreamPrefix:       req.UpstreamPrefix,
 		Version:              req.Version,
+		UpstreamVersion:      req.UpstreamVersion,
 		BlobStorage:          blobStorage,
 		GitCommitterName:     req.GitCommitterName,
 		GitCommitterEmail:    req.GitCommitterEmail,
@@ -1344,7 +1349,7 @@ func taglessBranchName(fullBranch string, pd *data.ProcessData) string {
 
 	// Simple case:  if our branch is not a modular stream branch, just return the normal <prefix><version><suffix> pattern
 	if !strings.HasPrefix(branch, "stream-") {
-		return fmt.Sprintf("%s%d%s", pd.BranchPrefix, pd.Version, pd.BranchSuffix)
+		return fmt.Sprintf("%s%d%s", pd.BranchPrefix, pd.UpstreamVersion, pd.BranchSuffix)
 	}
 
 	// index where the "-rhel-" starts near the end of the string
@@ -1357,5 +1362,6 @@ func taglessBranchName(fullBranch string, pd *data.ProcessData) string {
 	majorMinor := branch[rhelSpot+6:]
 
 	// return translated modular branch:
-	return fmt.Sprintf("%s%d%s-%s_%s", pd.BranchPrefix, pd.Version, pd.BranchSuffix, moduleString, majorMinor)
+
+	return fmt.Sprintf("%s%d%s-%s_%s", pd.BranchPrefix, pd.UpstreamVersion, pd.BranchSuffix, moduleString, majorMinor)
 }


### PR DESCRIPTION
…ion.

This is useful if you wanna import a centos7 package into rocky9.

Example, I want to have `ansible-2.9.27` that is available on EPEL7 on my rocky9 repos.

```
srpmproc \
  --import-branch-prefix "epel"\
  --rpm-prefix "https://src.fedoraproject.org/rpms/"\
  --version 7\
  --upstream-prefix file:///tmp/upstream/git/ \
  --upstream-version 9\
  --branch-prefix "r"\
  --cdn fedora\
  --source-rpm ansible\
  --storage-addr 'file:///tmp/s3/'
```

You can obviously use it backward, to port a fancy package from rocky9 to your old centos7 infra.

I didn't do anything related to patches tho.
