### PR TITLE
Change patch directive to maximum compatible form

### DIFF
--- a/pkg/directives/spec_change.go
+++ b/pkg/directives/spec_change.go
@@ -107,7 +107,7 @@ func sourcePatchOperationAfterLoop(req *sourcePatchOperationAfterLoopRequest) (b
 				*req.newLines = append(*req.newLines, fmt.Sprintf("%s:%s%s", field, spaces, file.Name))
 
 				if req.expectedField == "Patch" && file.AddToPrep {
-					val := fmt.Sprintf("%%patch%d", fieldNum)
+					val := fmt.Sprintf("%%patch -P%d", fieldNum)
 					if file.NPath > 0 {
 						val = fmt.Sprintf("%s -p%d", val, file.NPath)
 					}


### PR DESCRIPTION
The `%patchN` method of performing patches in `%prep` has long been deprecated and should *not* be used. The form of `%patch -PN` is preferred for maximum compatibility between all current and upcoming EL releases.