### PR TITLE
Fixingup error returns for directives

### DIFF
--- a/pkg/directives/patch.go
+++ b/pkg/directives/patch.go
@@ -34,10 +34,12 @@ import (
 func patch(cfg *srpmprocpb.Cfg, pd *data.ProcessData, _ *data.ModeData, patchTree *git.Worktree, pushTree *git.Worktree) error {
 	for _, patch := range cfg.Patch {
 		patchFile, err := patchTree.Filesystem.Open(patch.File)
+		pd.Log.Printf("[directives.patch] Parsing File: %s", patchFile.Name())
 		if err != nil {
 			return errors.New(fmt.Sprintf("COULD_NOT_OPEN_PATCH_FILE:%s", patch.File))
 		}
 		files, _, err := gitdiff.Parse(patchFile)
+
 		if err != nil {
 			pd.Log.Printf("could not parse patch file: %v", err)
 			return errors.New(fmt.Sprintf("COULD_NOT_PARSE_PATCH_FILE:%s", patch.File))
@@ -57,7 +59,7 @@ func patch(cfg *srpmprocpb.Cfg, pd *data.ProcessData, _ *data.ModeData, patchTre
 
 				err = gitdiff.Apply(&output, patchSubjectFile, patchedFile)
 				if err != nil {
-					pd.Log.Printf("could not apply patch: %v", err)
+					pd.Log.Printf("[directives.patch] could not apply patch: \"%v\" on \"%s\" from \"%s\"", err, srcPath, patchSubjectFile.Name())
 					return errors.New(fmt.Sprintf("COULD_NOT_APPLY_PATCH_WITH_SUBJECT:%s", srcPath))
 				}
 			}

--- a/pkg/srpmproc/patch.go
+++ b/pkg/srpmproc/patch.go
@@ -21,11 +21,9 @@
 package srpmproc
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -87,11 +85,7 @@ func cfgPatches(pd *data.ProcessData, md *data.ModeData, patchTree *git.Worktree
 
 			errs := directives.Apply(&cfg, pd, md, patchTree, pushTree)
 			if errs != nil {
-				err := json.NewEncoder(os.Stdout).Encode(errs)
-				if err != nil {
-					return err
-				}
-
+				fmt.Printf("errors: %v\n", errs)
 				return fmt.Errorf("directives could not be applied")
 			}
 		}


### PR DESCRIPTION
The processing of pkg/directives/patch.go will return an error type but handeling of it was attempting to use JSON encoding to print to screen. There is no reason to use that since the `error` type only has a string in it but doesn't get marshalled properly to json due to the private variables.
This is also the only time json marshaling is used so instead covert the error handling to just `fmt.Printf`.


## Example of failure now printing.
```
2024/07/12 13:46:11 [directives.patch] Parsing File: ROCKY/_supporting/0001-Enable-4K-pages-for-aarch64.patch
2024/07/12 13:46:11 [directives.patch] could not apply patch: "conflict: fragment line does not match src line" on "SOURCES/kernel-aarch64-debug.config" from "SOURCES/kernel-aarch64-debug.config"
errors: [COULD_NOT_APPLY_PATCH_WITH_SUBJECT:SOURCES/kernel-aarch64-debug.config]
2024/07/12 13:46:11 directives could not be applied
```